### PR TITLE
Log benchmarking progress

### DIFF
--- a/src/utilities/benchmark-file-helper.ts
+++ b/src/utilities/benchmark-file-helper.ts
@@ -2,12 +2,22 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "url";
 
+// The postfix used for benchmark files
+const BENCHMARK_FILE_POSTFIX = ".bm.ts";
+
+function postfixBenchmarkPath(path: string): string {
+  return `${path}${BENCHMARK_FILE_POSTFIX}`;
+}
+function unpostfixBenchmarkPath(path: string): string {
+  return path.replace(BENCHMARK_FILE_POSTFIX, "");
+}
+
 async function loadAndMapFiles<T>(
   dir: string,
   mappingFunc: (_: [fileName: string, file: any]) => T,
   fileFilter?: (fileName: string) => boolean
 ) {
-  let files = fs.readdirSync(dir).filter((f) => f.endsWith(".bm.ts"));
+  let files = fs.readdirSync(dir).filter((f) => f.endsWith(BENCHMARK_FILE_POSTFIX));
 
   // Filter files if relevant
   if (fileFilter) files = files.filter(fileFilter);
@@ -30,22 +40,22 @@ async function loadAndMapFiles<T>(
  * @param benchmarks Optional list of benchmarks to import
  * @returns Default functions exported by the given benchmarks
  */
-export async function loadBenchmarks(dir: string, benchmarks?: string[]) {
+export async function loadBenchmarks(dir: string, benchmarks?: string[]): Promise<[string, Function][]> {
   // Create filter function if necessary
   const filterFunction = benchmarks
-    ? (bmName: string) => benchmarks.includes(bmName.replace(".bm.ts", ""))
+    ? (bmName: string) => benchmarks.includes(unpostfixBenchmarkPath(bmName))
     : undefined;
 
   // Import filtered benchmarks and make sure they export a default function
   const importedBenchmarks = await loadAndMapFiles(
     dir,
-    ([_, importedFile]) => importedFile.default ?? null,
+    ([path, importedFile]) => [unpostfixBenchmarkPath(path), importedFile.default ?? null],
     filterFunction
   );
 
   // Return the functions
   return importedBenchmarks.filter(
-    (bm): bm is Function => typeof bm === "function"
+    (bm): bm is [string, Function] => typeof bm[1] === "function"
   );
 }
 
@@ -58,7 +68,7 @@ export async function getBenchmarkNames(dir: string) {
   // Get names of benchmarks
   const benchmarks = await loadAndMapFiles(dir, ([file, importedFile]) =>
     typeof importedFile.default === "function"
-      ? file.replace(".bm.ts", "")
+      ? unpostfixBenchmarkPath(file)
       : null
   );
 
@@ -75,7 +85,7 @@ export async function validateBenchmarks(dir: string, benchmarks: string[]) {
   // Import and process all benchmarks
   const benchmarkChecks = await Promise.all(
     benchmarks.map(async (bm) => {
-      const fileUrl = pathToFileURL(path.join(dir, `${bm}.bm.ts`)).href;
+      const fileUrl = pathToFileURL(path.join(dir, postfixBenchmarkPath(bm))).href;
       const importedFile = await import(fileUrl);
       return typeof importedFile.default === "function" ? true : false;
     })

--- a/src/utilities/benchmark-file-helper.ts
+++ b/src/utilities/benchmark-file-helper.ts
@@ -3,13 +3,13 @@ import path from "node:path";
 import { pathToFileURL } from "url";
 
 // The postfix used for benchmark files
-const BENCHMARK_FILE_POSTFIX = ".bm.ts";
+const BENCHMARK_FILE_EXTENSION = ".bm.ts";
 
-function postfixBenchmarkPath(path: string): string {
-  return `${path}${BENCHMARK_FILE_POSTFIX}`;
+function addBenchmarkExtension(path: string): string {
+  return `${path}${BENCHMARK_FILE_EXTENSION}`;
 }
-function unpostfixBenchmarkPath(path: string): string {
-  return path.replace(BENCHMARK_FILE_POSTFIX, "");
+function removeBenchmarkExtension(path: string): string {
+  return path.replace(BENCHMARK_FILE_EXTENSION, "");
 }
 
 async function loadAndMapFiles<T>(
@@ -17,7 +17,7 @@ async function loadAndMapFiles<T>(
   mappingFunc: (_: [fileName: string, file: any]) => T,
   fileFilter?: (fileName: string) => boolean
 ) {
-  let files = fs.readdirSync(dir).filter((f) => f.endsWith(BENCHMARK_FILE_POSTFIX));
+  let files = fs.readdirSync(dir).filter((f) => f.endsWith(BENCHMARK_FILE_EXTENSION));
 
   // Filter files if relevant
   if (fileFilter) files = files.filter(fileFilter);
@@ -43,13 +43,13 @@ async function loadAndMapFiles<T>(
 export async function loadBenchmarks(dir: string, benchmarks?: string[]): Promise<[string, Function][]> {
   // Create filter function if necessary
   const filterFunction = benchmarks
-    ? (bmName: string) => benchmarks.includes(unpostfixBenchmarkPath(bmName))
+    ? (bmName: string) => benchmarks.includes(removeBenchmarkExtension(bmName))
     : undefined;
 
   // Import filtered benchmarks and make sure they export a default function
   const importedBenchmarks = await loadAndMapFiles(
     dir,
-    ([path, importedFile]) => [unpostfixBenchmarkPath(path), importedFile.default ?? null],
+    ([path, importedFile]) => [removeBenchmarkExtension(path), importedFile.default ?? null],
     filterFunction
   );
 
@@ -68,7 +68,7 @@ export async function getBenchmarkNames(dir: string) {
   // Get names of benchmarks
   const benchmarks = await loadAndMapFiles(dir, ([file, importedFile]) =>
     typeof importedFile.default === "function"
-      ? unpostfixBenchmarkPath(file)
+      ? removeBenchmarkExtension(file)
       : null
   );
 
@@ -85,7 +85,7 @@ export async function validateBenchmarks(dir: string, benchmarks: string[]) {
   // Import and process all benchmarks
   const benchmarkChecks = await Promise.all(
     benchmarks.map(async (bm) => {
-      const fileUrl = pathToFileURL(path.join(dir, postfixBenchmarkPath(bm))).href;
+      const fileUrl = pathToFileURL(path.join(dir, addBenchmarkExtension(bm))).href;
       const importedFile = await import(fileUrl);
       return typeof importedFile.default === "function" ? true : false;
     })

--- a/src/utilities/benchmark-runner.ts
+++ b/src/utilities/benchmark-runner.ts
@@ -30,7 +30,7 @@ export default async function startBenchmark(options: InputOptions) {
   /** Loop through every repetitions */
   for (let repetition = 1; repetition <= options.repetitions; repetition++) {
     /** Loop through every framework and perform the benchmark */
-    for (const framework of frameworks) {
+    for (const [frameworkIndex, framework] of frameworks.entries()) {
       const workerData: WorkerData = {
         port: options.serverPort,
         framework,
@@ -70,7 +70,8 @@ export default async function startBenchmark(options: InputOptions) {
         options.benchmarksPath,
         options.chosenBenchmarks
       );
-      for (const benchmark of benchmarks) {
+      for (const [benchmarkIndex, [benchmarkName, benchmark]] of benchmarks.entries()) {
+        console.log(`Benchmarking ${framework} with ${benchmarkName}.. (benchmark ${benchmarkIndex+1}/${benchmarks.length}) (framework ${frameworkIndex+1}/${frameworks.length}) (repetition ${repetition}/${options.repetitions})`);
         await benchmark(benchmarkInput);
       }
 


### PR DESCRIPTION
This should make it easier to know how far along the benchmarking progress is. If a benchmark fails, this also makes it much easier to figure out which benchmark it was.