### PR TITLE
Improve page loading utility

### DIFF
--- a/src/benchmarks/navigate-all-pages.bm.ts
+++ b/src/benchmarks/navigate-all-pages.bm.ts
@@ -1,10 +1,10 @@
-import { By, until } from "selenium-webdriver";
+import { By } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
+  pageIsLoaded,
   prepareBrowser,
   profilerWrapper,
-  promisifiedTimeout,
   scrollToElement,
   simulateClick,
 } from "../utilities/benchmark-utilities";
@@ -13,20 +13,12 @@ import BenchmarkInput from "./benchmark-types";
 const BENCHMARK_NAME = "benchmark-types" as const;
 
 async function scrollAndNavigate(driver: Driver, hrefSelector: string) {
-  // Wait for header to be visible
-  const title = await driver.findElement(By.css("main h1"));
-  await driver.wait(until.elementIsVisible(title));
-
   // Scroll to footer and open second static page
   await scrollToElement(driver, "footer");
-  const firstFooterLink = await driver.findElement(
+  const footerLink = await driver.findElement(
     By.css(`footer a[href*="${hrefSelector}"]`),
   );
-  await simulateClick(
-    driver,
-    firstFooterLink,
-    async () => await promisifiedTimeout(1000),
-  );
+  await simulateClick(driver, footerLink);
 }
 
 export default async function benchmark(options: BenchmarkInput) {
@@ -35,9 +27,7 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link, async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link);
 
     // Scroll to footer and open second static page
     for (const hrefSelector of [
@@ -49,6 +39,7 @@ export default async function benchmark(options: BenchmarkInput) {
       "/list",
     ]) {
       await scrollAndNavigate(driver, hrefSelector);
+      await pageIsLoaded(driver);
     }
     await scrollToElement(driver, "footer");
   };

--- a/src/benchmarks/navigate-static.bm.ts
+++ b/src/benchmarks/navigate-static.bm.ts
@@ -1,7 +1,6 @@
-import { until } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
   prepareBrowser,
   profilerWrapper,
   promisifiedTimeout,
@@ -16,12 +15,10 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link + "/static-1/", async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link + "/static-1/");
 
-    // Wait for the page to fully load
-    await promisifiedTimeout(2000);
+    // A short visit
+    await promisifiedTimeout(500);
   };
 
   await profilerWrapper({

--- a/src/benchmarks/subpage-faq.bm.ts
+++ b/src/benchmarks/subpage-faq.bm.ts
@@ -1,7 +1,7 @@
-import { By, until } from "selenium-webdriver";
+import { By } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
   prepareBrowser,
   profilerWrapper,
   scrollToElement,
@@ -17,9 +17,7 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link + "/faq/", async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link + "/faq/");
 
     const summaryButtons = await driver.findElements(By.css(".summary"));
 

--- a/src/benchmarks/subpage-list.bm.ts
+++ b/src/benchmarks/subpage-list.bm.ts
@@ -1,7 +1,7 @@
-import { By, until, Select } from "selenium-webdriver";
+import { By, Select } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
   prepareBrowser,
   profilerWrapper,
   promisifiedTimeout,
@@ -17,9 +17,7 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link + "/list/", async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link + "/list/");
 
     // Change sorting strategy
     const selectElement = await driver.findElement(By.css(".controls select"));

--- a/src/benchmarks/subpage-live.bm.ts
+++ b/src/benchmarks/subpage-live.bm.ts
@@ -1,7 +1,6 @@
-import { until } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
   prepareBrowser,
   profilerWrapper,
   promisifiedTimeout,
@@ -16,9 +15,7 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link + "/live/", async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link + "/live/");
 
     // The the page run for 60 seconds then end the test
     await promisifiedTimeout(60000);

--- a/src/benchmarks/subpage-tooltip.bm.ts
+++ b/src/benchmarks/subpage-tooltip.bm.ts
@@ -1,7 +1,7 @@
-import { By, until } from "selenium-webdriver";
+import { By } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
-  openPageAndWait,
+  loadPage,
   prepareBrowser,
   profilerWrapper,
   promisifiedTimeout,
@@ -18,9 +18,7 @@ export default async function benchmark(options: BenchmarkInput) {
   };
 
   const performTest = async (driver: Driver) => {
-    await openPageAndWait(driver, options.link + "/tooltips/", async () => {
-      await driver.wait(until.titleIs("Test site"), 10000);
-    });
+    await loadPage(driver, options.link + "/tooltips/");
     const tooltips = await driver.findElements(By.css(".tooltip"));
 
     for (const [index, tooltip] of tooltips.entries()) {

--- a/src/utilities/benchmark-utilities.ts
+++ b/src/utilities/benchmark-utilities.ts
@@ -179,7 +179,6 @@ export async function scrollToBottom(driver: Driver) {
  * Simulate a real click by hovering over the button before clicking.
  * @param driver The driver to control the browser instance
  * @param element Clickable element to be clicked
- * @param waitFunc If provided, await its execution before returning
  */
 export async function simulateClick(driver: Driver, element: WebElement) {
   // Hover over element before clicking
@@ -189,4 +188,5 @@ export async function simulateClick(driver: Driver, element: WebElement) {
     .perform();
   await promisifiedTimeout(300);
   await element.click();
+  await promisifiedTimeout(100);
 }

--- a/src/utilities/benchmark-utilities.ts
+++ b/src/utilities/benchmark-utilities.ts
@@ -1,4 +1,4 @@
-import { WebElement } from "selenium-webdriver";
+import { By, until, WebElement } from "selenium-webdriver";
 import { Driver } from "selenium-webdriver/firefox";
 import {
   BuilderOptions,
@@ -112,26 +112,30 @@ export async function prepareBrowser(driver: Driver) {
   await driver.manage().deleteAllCookies();
 }
 
-interface openPageAndWaitInput {
-  driver: Driver;
-  link: string;
-  waitFunc: () => Promise<void>;
+/**
+ * Navigate to page and wait until the page is loaded.
+ *
+ * Uses the `pageIsLoaded` utility to wait for page load.
+ *
+ * @param driver The driver to control the browser instance
+ * @param link The link that should be navigated to
+ */
+export async function loadPage(driver: Driver, link: string) {
+  await driver.navigate().to(link);
+  await pageIsLoaded(driver);
 }
 
 /**
- * Navigate to page and wait for it bo be loaded
+ * Wait until the page is loaded.
+ *
+ * This will wait for the top of the page's DOM to load, but will not wait for the rest of the page to load,
+ * as it might be lazy-loaded and thus will never load unless it is scrolled into view.
+ *
  * @param driver The driver to control the browser instance
- * @param link The link that should be navigated to
- * @param title The expected title of the page
  */
-export async function openPageAndWait(
-  driver: Driver,
-  link: string,
-  waitFunc: () => Promise<void>,
-) {
-  await driver.navigate().to(link);
-  await waitFunc();
-  await promisifiedTimeout(1000);
+export async function pageIsLoaded(driver: Driver) {
+  await driver.wait(until.elementLocated(By.css("h1")), 10000);
+  await driver.wait(until.elementLocated(By.css("main p")), 10000);
 }
 
 /**
@@ -177,11 +181,7 @@ export async function scrollToBottom(driver: Driver) {
  * @param element Clickable element to be clicked
  * @param waitFunc If provided, await its execution before returning
  */
-export async function simulateClick(
-  driver: Driver,
-  element: WebElement,
-  waitFunc?: () => Promise<void>,
-) {
+export async function simulateClick(driver: Driver, element: WebElement) {
   // Hover over element before clicking
   await driver
     .actions({ async: true })
@@ -189,7 +189,4 @@ export async function simulateClick(
     .perform();
   await promisifiedTimeout(300);
   await element.click();
-
-  // Await the wait function
-  if (waitFunc) await waitFunc();
 }


### PR DESCRIPTION
The page load utility now waits for the presence of h1 and p elements in the main page, ensuring the page is loaded before allowing the code to continue. This allows us to remove a lot of long waits and other custom logic to ensure the page is loaded.